### PR TITLE
Feat: SkyButton components fix

### DIFF
--- a/client/src/components/buttons/SkyButton.jsx
+++ b/client/src/components/buttons/SkyButton.jsx
@@ -5,7 +5,7 @@ function SkyButton(props) {
     <div className="block">
       <a
         href="/"
-        className="bg-[#e1ecf4] border border-solid	rounded border-[#39739d] text-[#39739d] p-[10px] text-[13px] font-normal leading-4 relative hover:bg-[#b3d3ea]"
+        className="bg-[#e1ecf4] border-[1px] border-solid	rounded border-[#39739d] text-[#39739d] p-[10px] text-[13px] font-normal leading-4 relative hover:bg-[#b3d3ea]"
       >
         {props.text}
       </a>


### PR DESCRIPTION
하늘색 버튼 테두리 적용 안되는 버그 수정

수정 전
<img width="56" alt="image" src="https://user-images.githubusercontent.com/57666791/209091962-ef1d9410-686a-466b-99d3-2baf849ab334.png">

수정 후
<img width="98" alt="image" src="https://user-images.githubusercontent.com/57666791/209091874-d185fcfa-3318-4b80-bc74-371cf99af450.png">
