### PR TITLE
Feat: OpenIdButton component implement

### DIFF
--- a/client/src/components/OpenIdButton.jsx
+++ b/client/src/components/OpenIdButton.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-function OpenIdButton(props) {
+function OpenIdButton({ company, text }) {
   return (
     <>
-      {props.company !== 'google' ? null : (
+      {company !== 'google' ? null : (
         <button className="flex items-center border-[1px] border-[#d7d9dc] rounded-[5px] w-full bg-[#ffffff]">
           <svg
             className="my-[8px] ml-auto mr-[5px]"
@@ -28,11 +28,11 @@ function OpenIdButton(props) {
               fill="#EA4335"
             ></path>
           </svg>
-          <div className="mr-auto text-sm">Sign up with Google</div>
+          <div className="mr-auto text-sm">{text} with Google</div>
         </button>
       )}
 
-      {props.company !== 'github' ? null : (
+      {company !== 'github' ? null : (
         <button className="flex items-center border-[1px] border-[#2f3337] rounded-[5px] w-full bg-[#2f3337]">
           <svg
             className="my-[8px] ml-auto mr-[5px]"
@@ -46,12 +46,12 @@ function OpenIdButton(props) {
             ></path>
           </svg>
           <div className="mr-auto text-sm text-[#ffffff]">
-            Sign up with GitHub
+            {text} with GitHub
           </div>
         </button>
       )}
 
-      {props.company !== 'facebook' ? null : (
+      {company !== 'facebook' ? null : (
         <button className="flex items-center border-[1px] border-[#385499] rounded-[5px] w-full bg-[#385499]">
           <svg
             className="my-[8px] ml-auto mr-[5px]"
@@ -65,7 +65,7 @@ function OpenIdButton(props) {
             ></path>
           </svg>
           <div className="mr-auto text-sm text-[#ffffff]">
-            Sign up with Facebook
+            {text} with Facebook
           </div>
         </button>
       )}


### PR DESCRIPTION
OpenIdButton 컴포넌트 구현

1. props.company로 'google', 'github', 'facebook' 중 입력하면 해당 버튼이 나오도록 구현
2. props.text로 앞 글자를 기입할 수 있도록 구현 (ex. "Log in" with Google, "Sign up" with Facebook)

<img width="341" alt="image" src="https://user-images.githubusercontent.com/57666791/209331315-8088ef3c-7c4b-4205-b52e-d705b7389628.png">

<img width="308" alt="image" src="https://user-images.githubusercontent.com/57666791/209332429-30bee4dc-a9a7-4813-8b14-238cc5237aa3.png">


